### PR TITLE
chore: fix semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "overrides": {
+    "conventional-changelog-conventionalcommits": ">= 8.0.0"
   }
 }


### PR DESCRIPTION
Semantic Release is currently failing: https://github.com/sanity-io/sanity-plugin-personalisation/actions/runs/11972989121/job/33381058091

It's a known issue when using commitlint: https://github.com/semantic-release/release-notes-generator/issues/657#issuecomment-2144694326

Once commitlint is updated we'll remove this workaround: https://github.com/conventional-changelog/commitlint/pull/4063